### PR TITLE
ENSWEB-5690: fix configpacker breaking due to web_data provided as json

### DIFF
--- a/modules/EnsEMBL/Web/ConfigPacker.pm
+++ b/modules/EnsEMBL/Web/ConfigPacker.pm
@@ -73,21 +73,13 @@ sub _summarise_core_tables {
   my $analysis = {};
   foreach my $a_aref (@$t_aref) { 
     ## Strip out "crap" at front and end! probably some q(')s...
-    ( my $A = $a_aref->[6] ) =~ s/^[^{]+//;
-    $A =~ s/[^}]+$//;
-    my $T = eval($A);
-    if (ref($T) ne 'HASH') {
-      if ($A) {
-        warn "Deleting web_data for $db_key:".$a_aref->[1].", check for syntax error";
-      }
-      $T = {};
-    }
+    my $web_data = $a_aref->[6] ? from_json($a_aref->[6]) : {};
     $analysis->{ $a_aref->[0] } = {
       'logic_name'  => $a_aref->[1],
       'name'        => $a_aref->[3],
       'description' => $a_aref->[4],
       'displayable' => $a_aref->[5],
-      'web_data'    => $T
+      'web_data'    => $web_data
     };
   }
   ## Set last repeat mask date whilst we're at it, as needed by BLAST configuration, below


### PR DESCRIPTION
Since bacteria has its own `ConfigPacker`, I've applied @ens-ap5's fix to it, so that the packed files get generated properly. The `ensembl-webcode` commit that I referred to is: https://github.com/Ensembl/ensembl-webcode/commit/37ff3bff91b4629f9ac8b3b83656dcf2279289fc.

I've applied the fix to bacteria staging and the species packed files generated successfully.