### PR TITLE
Enable alphafold view for bacterial transcripts

### DIFF
--- a/modules/EnsEMBL/Web/Configuration/Transcript.pm
+++ b/modules/EnsEMBL/Web/Configuration/Transcript.pm
@@ -140,6 +140,11 @@ sub modify_tree {
 
       $tree_node->append($D);
 
+      $tree_node->append($self->create_node('AFDB', 'AlphaFold predicted model',
+        [qw( alignment EnsEMBL::Web::Component::Transcript::AFDB )],
+        { 'availability' => 'transcript translation has_afdb','concise' => 'AlphaFold predicted model' }
+      ));
+
       $url = $hub->url({
                   type   => 'Transcript',
                   action => 'ProtVariations_'.$p,


### PR DESCRIPTION
Enabling Alphafold view for bacterial transcripts, because we are now importing alphafold analysis for bacteria as well.

**Sandbox:** http://wp-np2-1e.ebi.ac.uk:8460

**Example transcript with alphafold analysis:** http://wp-np2-1e.ebi.ac.uk:8460/Gloeobacter_violaceus_pcc_7421_gca_000011385/Transcript/Summary?g=BAC91936;r=Chromosome:4197908-4198249;t=BAC91936