### PR TITLE
Call frameshift intron glossary_helptip via hub in transcript summary

### DIFF
--- a/modules/EnsEMBL/Web/Component/Transcript/TranscriptSummary.pm
+++ b/modules/EnsEMBL/Web/Component/Transcript/TranscriptSummary.pm
@@ -117,7 +117,7 @@ sub content {
   ## add frameshift introns info
   my $frameshift_introns = $object->get_frameshift_introns;
 
-  $table->add_row('Frameshift introns', $self->glossary_helptip('Frameshift introns', 'Frameshift intron') . " occur at intron number(s)  $frameshift_introns.") if $frameshift_introns;
+  $table->add_row('Frameshift introns', glossary_helptip($self->hub, 'Frameshift introns', 'Frameshift intron') . " occur at intron number(s)  $frameshift_introns.") if $frameshift_introns;
 
 
   ## add trans-spliced transcript info


### PR DESCRIPTION
An error occurs in the transcript summary view of bacterial transcripts with frameshift introns ( e.g. [Anaplasma phagocytophilum transcript ABD43899](https://staging-bacteria.ensembl.org/Anaplasma_phagocytophilum_str_hz_gca_000013125/Transcript/Summary?db=core;g=APH_0479;t=ABD43899) ).

This PR would address the error by updating [line 120 of the eg-web-bacteria TranscriptSummary module](https://github.com/EnsemblGenomes/eg-web-bacteria/blob/add92fc609b262682bbe134eb839adedd8731260/modules/EnsEMBL/Web/Component/Transcript/TranscriptSummary.pm#L120) to call `glossary_helptip` via the hub, in the same way as the [corresponding line of the ensembl-webcode TranscriptSummary module](https://github.com/Ensembl/ensembl-webcode/blob/8d4ffebfe67f6232a71a3f5bb070a924bc60bcce/modules/EnsEMBL/Web/Component/Transcript/TranscriptSummary.pm#L188).

I haven't tested this change on Ensembl Bacteria directly, but what I have done is reproduced the error in Ensembl Protists by updating its `TranscriptSummary` module to call `glossary_helptip` as it is currently done in `eg-web-bacteria`.

In this example, the error occurs on the [Protists sandbox](http://wp-np2-35.ebi.ac.uk:5099/Plasmodium_falciparum/Transcript/Summary?db=core;t=PF3D7_0221300.1), but not on [Protists staging](https://staging-protists.ensembl.org/Plasmodium_falciparum/Transcript/Summary?db=core;t=PF3D7_0221300.1).
