### PR TITLE
Reforge Bacteria glossary links

### DIFF
--- a/modules/EnsEMBL/Web/Component/Transcript/TranscriptSummary.pm
+++ b/modules/EnsEMBL/Web/Component/Transcript/TranscriptSummary.pm
@@ -188,7 +188,7 @@ sub content {
   }
 
   ## add gencode basic info
-  $table->add_row('GENCODE basic gene', qq(This transcript is a member of the <a href="/Help/Glossary?id=500" class="popup">Gencode basic</a> gene set.)) if(@{$transcript->get_all_Attributes('gencode_basic')});
+  $table->add_row('GENCODE basic gene', qq(This transcript is a member of the <a href="/glossary/ENSGLOSSARY_0000020" class="popup">Gencode basic</a> gene set.)) if(@{$transcript->get_all_Attributes('gencode_basic')});
 
   return $table->render;
 }


### PR DESCRIPTION
This PR would reforge a glossary link in the Bacteria-specific `TranscriptSummary` component module.
